### PR TITLE
Chunk ScanAllFactions main loop + toc 120005

### DIFF
--- a/DataStore_Reputations/DataStore_Reputations.lua
+++ b/DataStore_Reputations/DataStore_Reputations.lua
@@ -462,21 +462,43 @@ local function ScanSingleFaction(factionID, index)
 		+ bit64:LeftShift(value, 8)					-- bits 8+ : value
 end
 
+-- Chunk the main faction loop across frames. On 12.0+ retail there are
+-- 400+ factions when categories are expanded by SaveHeaders, and each
+-- ScanSingleFaction makes 4-5 API calls (IsMajorFaction, GetFriendshipReputation,
+-- GetFriendshipReputationRanks, IsFactionParagon, GetFactionParagonInfo).
+-- Doing all of that in one synchronous pass exceeds WoW's script budget.
+local FACTIONS_PER_FRAME = 60
+local factionScanGen = 0
+
 local function ScanAllFactions()
 	SaveHeaders()
 
 	thisCharacter.guildName = GetGuildInfo("player")
 
-	for i = 1, API_GetNumFactions() do
-		local factionID = select(2, API_GetFactionInfo(i))
-		
-		if factionID then
-			ScanSingleFaction(factionID, i)		-- pass the index for cata.
+	factionScanGen = factionScanGen + 1
+	local myGen = factionScanGen
+	local total = API_GetNumFactions()
+	local i = 1
+
+	local function ProcessBatch()
+		if myGen ~= factionScanGen then return end		-- superseded by a newer scan
+		local endIdx = math.min(i + FACTIONS_PER_FRAME - 1, total)
+		while i <= endIdx do
+			local factionID = select(2, API_GetFactionInfo(i))
+			if factionID then
+				ScanSingleFaction(factionID, i)		-- pass the index for cata.
+			end
+			i = i + 1
+		end
+		if i <= total then
+			C_Timer.After(0, ProcessBatch)
+		else
+			RestoreHeaders()
+			thisCharacter.lastUpdate = time()
 		end
 	end
 
-	RestoreHeaders()
-	thisCharacter.lastUpdate = time()
+	ProcessBatch()
 end
 
 local function ScanGuildReputation()

--- a/DataStore_Reputations/DataStore_Reputations.toc
+++ b/DataStore_Reputations/DataStore_Reputations.toc
@@ -1,4 +1,4 @@
-## Interface: 120000
+## Interface: 120000, 120005
 ## Title: DataStore_Reputations
 ## IconTexture: Interface\Icons\garrison_building_storehouse
 


### PR DESCRIPTION
## Summary
- 12.0 retail has 400+ factions when SaveHeaders expands all categories. ScanSingleFaction makes 4-5 API calls per entry. The synchronous loop blows WoW's "script ran too long" budget on PLAYER_ALIVE.
- Chunk the main loop into 60 factions per frame, yielding via C_Timer.After(0, ...). RestoreHeaders + lastUpdate run after the last chunk completes (they need to bracket the chunked walk because of header state).
- Generation counter cancels in-flight chunked passes when a fresh ScanAllFactions starts.
- Declare 12.0.5 in toc.

## Notes
- The existing 3s debounce in OnUpdateFaction is preserved unchanged - this PR addresses the underlying scan cost, not the trigger frequency.
- ScanGuildReputation is left synchronous (single faction match in a tight loop, cheap).

## Test plan
- [ ] Log in fresh on 12.0.5 - no `script ran too long` from DataStore_Reputations.
- [ ] After ~1s, `/dump DataStore:GetReputationInfo("char", factionID)` returns expected data across all categories (including Khaz Algar / Midnight factions previously dropped mid-scan).
- [ ] Trigger a rep change via mob kill - debounce + chunked rescan completes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)